### PR TITLE
apply clippy lints

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,9 +144,7 @@ pub fn cross<T: Scalar>(a: Vec3<T>, b: Vec3<T>) -> Vec3<T> {
 ///
 /// [wiki]: https://en.wikipedia.org/wiki/Dot_product
 pub fn dot<T: Scalar, const N: usize>(a: Vector<T, N>, b: Vector<T, N>) -> T {
-    if N == 0 {
-        panic!("the dot product of 0-dimensional vectors is not useful");
-    }
+    assert!(N != 0, "the dot product of 0-dimensional vectors is not useful");
 
     let mut out = a[0] * b[0];
     for i in 1..N {

--- a/src/mat/mod.rs
+++ b/src/mat/mod.rs
@@ -519,7 +519,7 @@ impl<T: Scalar, const C: usize, const R: usize> IndexMut<usize> for Matrix<T, C,
 }
 
 impl<T: Scalar, const C: usize, const R: usize> ops::Add for Matrix<T, C, R> {
-    type Output = Matrix<T, C, R>;
+    type Output = Self;
     fn add(self, rhs: Self) -> Self::Output {
         self.zip_map(rhs, |l, r| l + r)
     }
@@ -532,7 +532,7 @@ impl<T: Scalar, const C: usize, const R: usize> ops::AddAssign for Matrix<T, C, 
 }
 
 impl<T: Scalar, const C: usize, const R: usize> ops::Sub for Matrix<T, C, R> {
-    type Output = Matrix<T, C, R>;
+    type Output = Self;
     fn sub(self, rhs: Self) -> Self::Output {
         self.zip_map(rhs, |l, r| l - r)
     }
@@ -545,7 +545,7 @@ impl<T: Scalar, const C: usize, const R: usize> ops::SubAssign for Matrix<T, C, 
 }
 
 impl<T: Scalar, const C: usize, const R: usize> ops::Mul<T> for Matrix<T, C, R> {
-    type Output = Matrix<T, C, R>;
+    type Output = Self;
     fn mul(self, rhs: T) -> Self::Output {
         self.map(|elem| elem * rhs)
     }
@@ -558,7 +558,7 @@ impl<T: Scalar, const C: usize, const R: usize> ops::MulAssign<T> for Matrix<T, 
 }
 
 impl<T: Scalar, const C: usize, const R: usize> ops::Div<T> for Matrix<T, C, R> {
-    type Output = Matrix<T, C, R>;
+    type Output = Self;
     fn div(self, rhs: T) -> Self::Output {
         self.map(|elem| elem / rhs)
     }

--- a/src/mat/tests.rs
+++ b/src/mat/tests.rs
@@ -1,4 +1,4 @@
-use crate::*;
+use crate::{Mat2, Mat4f, Matrix};
 
 
 #[test]

--- a/src/vec/mod.rs
+++ b/src/vec/mod.rs
@@ -1,8 +1,8 @@
 #[macro_use]
 mod shared;
 
-pub mod point;
-pub mod vector;
+pub(crate) mod point;
+pub(crate) mod vector;
 
 #[cfg(test)]
 mod tests;

--- a/src/vec/mod.rs
+++ b/src/vec/mod.rs
@@ -1,8 +1,8 @@
 #[macro_use]
 mod shared;
 
-pub(crate) mod point;
-pub(crate) mod vector;
+pub mod point;
+pub mod vector;
 
 #[cfg(test)]
 mod tests;

--- a/src/vec/point.rs
+++ b/src/vec/point.rs
@@ -95,8 +95,8 @@ impl<T: Scalar, const N: usize> Point<T, N> {
         let mut total_displacement = it.next()?.to_vec();
         let mut count = T::one();
         for p in it {
-            total_displacement = total_displacement + p.to_vec();
-            count = count + T::one();
+            total_displacement += p.to_vec();
+            count += T::one();
         }
 
         Some((total_displacement / count).to_point())
@@ -127,9 +127,9 @@ pub fn point3<T: Scalar>(x: T, y: T, z: T) -> Point3<T> {
 }
 
 impl<T: Scalar, const N: usize> ops::Add<Vector<T, N>> for Point<T, N> {
-    type Output = Point<T, N>;
+    type Output = Self;
     fn add(self, rhs: Vector<T, N>) -> Self::Output {
-        Point(array::from_fn(|i| self[i] + rhs[i]))
+        Self(array::from_fn(|i| self[i] + rhs[i]))
     }
 }
 
@@ -142,9 +142,9 @@ impl<T: Scalar, const N: usize> ops::AddAssign<Vector<T, N>> for Point<T, N> {
 }
 
 impl<T: Scalar, const N: usize> ops::Sub<Vector<T, N>> for Point<T, N> {
-    type Output = Point<T, N>;
+    type Output = Self;
     fn sub(self, rhs: Vector<T, N>) -> Self::Output {
-        Point(array::from_fn(|i| self[i] - rhs[i]))
+        Self(array::from_fn(|i| self[i] - rhs[i]))
     }
 }
 
@@ -156,9 +156,9 @@ impl<T: Scalar, const N: usize> ops::SubAssign<Vector<T, N>> for Point<T, N> {
     }
 }
 
-impl<T: Scalar, const N: usize> ops::Sub<Point<T, N>> for Point<T, N> {
+impl<T: Scalar, const N: usize> ops::Sub<Self> for Point<T, N> {
     type Output = Vector<T, N>;
-    fn sub(self, rhs: Point<T, N>) -> Self::Output {
+    fn sub(self, rhs: Self) -> Self::Output {
         Vector(array::from_fn(|i| self[i] - rhs[i]))
     }
 }

--- a/src/vec/shared.rs
+++ b/src/vec/shared.rs
@@ -126,9 +126,9 @@ macro_rules! shared_impls {
             }
         }
 
-        impl<T: Scalar, const N: usize> Into<[T; N]> for $ty<T, N> {
-            fn into(self) -> [T; N] {
-                self.0
+        impl<T: Scalar, const N: usize> From<$ty<T, N>> for [T; N] {
+            fn from(src: $ty<T, N>) -> Self {
+                src.0
             }
         }
 

--- a/src/vec/tests.rs
+++ b/src/vec/tests.rs
@@ -1,4 +1,4 @@
-use crate::*;
+use crate::{Point, Point3f, Vec2, Vec3, Vec3f, point2, point3, vec2, vec3, vec4};
 
 #[test]
 fn add_point_vec() {

--- a/src/vec/vector.rs
+++ b/src/vec/vector.rs
@@ -51,7 +51,7 @@ impl<T: Scalar, const N: usize> Vector<T, N> {
 
     /// Returns `true` if this vector is the zero vector (all components 0).
     pub fn is_zero(&self) -> bool {
-        self.0.iter().all(|c| c.is_zero())
+        self.0.iter().all(num_traits::Zero::is_zero)
     }
 
     /// Returns a unit vector in x direction.
@@ -152,7 +152,7 @@ impl<T: Scalar, const N: usize> Vector<T, N> {
     where
         T: Float,
     {
-        *self = *self / self.length();
+        *self /= self.length();
     }
 
     /// Returns the average of all given vectors or `None` if the given iterator
@@ -170,7 +170,7 @@ impl<T: Scalar, const N: usize> Vector<T, N> {
         let mut count = T::one();
         for v in it {
             total += v;
-            count = count + T::one();
+            count += T::one();
         }
 
         Some(total / count)
@@ -211,30 +211,30 @@ pub fn vec4<T: Scalar>(x: T, y: T, z: T, w: T) -> Vec4<T> {
     Vec4::new(x, y, z, w)
 }
 
-impl<T: Scalar, const N: usize> ops::Add<Vector<T, N>> for Vector<T, N> {
-    type Output = Vector<T, N>;
-    fn add(self, rhs: Vector<T, N>) -> Self::Output {
+impl<T: Scalar, const N: usize> ops::Add<Self> for Vector<T, N> {
+    type Output = Self;
+    fn add(self, rhs: Self) -> Self::Output {
         self.zip_map(rhs, |l, r| l + r)
     }
 }
 
-impl<T: Scalar, const N: usize> ops::AddAssign<Vector<T, N>> for Vector<T, N> {
-    fn add_assign(&mut self, rhs: Vector<T, N>) {
+impl<T: Scalar, const N: usize> ops::AddAssign<Self> for Vector<T, N> {
+    fn add_assign(&mut self, rhs: Self) {
         for (lhs, rhs) in IntoIterator::into_iter(&mut self.0).zip(rhs.0) {
             *lhs += rhs;
         }
     }
 }
 
-impl<T: Scalar, const N: usize> ops::Sub<Vector<T, N>> for Vector<T, N> {
-    type Output = Vector<T, N>;
-    fn sub(self, rhs: Vector<T, N>) -> Self::Output {
+impl<T: Scalar, const N: usize> ops::Sub<Self> for Vector<T, N> {
+    type Output = Self;
+    fn sub(self, rhs: Self) -> Self::Output {
         self.zip_map(rhs, |l, r| l - r)
     }
 }
 
-impl<T: Scalar, const N: usize> ops::SubAssign<Vector<T, N>> for Vector<T, N> {
-    fn sub_assign(&mut self, rhs: Vector<T, N>) {
+impl<T: Scalar, const N: usize> ops::SubAssign<Self> for Vector<T, N> {
+    fn sub_assign(&mut self, rhs: Self) {
         for (lhs, rhs) in IntoIterator::into_iter(&mut self.0).zip(rhs.0) {
             *lhs -= rhs;
         }
@@ -253,9 +253,9 @@ where
 
 /// Scalar multipliation: `vector * scalar`.
 impl<T: Scalar, const N: usize> ops::Mul<T> for Vector<T, N> {
-    type Output = Vector<T, N>;
+    type Output = Self;
     fn mul(self, rhs: T) -> Self::Output {
-        self.map(|c| c * rhs.clone())
+        self.map(|c| c * rhs)
     }
 }
 
@@ -281,16 +281,16 @@ impl_scalar_mul!(f32, f64, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128);
 impl<T: Scalar, const N: usize> ops::MulAssign<T> for Vector<T, N> {
     fn mul_assign(&mut self, rhs: T) {
         for c in &mut self.0 {
-            *c *= rhs.clone();
+            *c *= rhs;
         }
     }
 }
 
 /// Scalar division: `vector / scalar`.
 impl<T: Scalar, const N: usize> ops::Div<T> for Vector<T, N> {
-    type Output = Vector<T, N>;
+    type Output = Self;
     fn div(self, rhs: T) -> Self::Output {
-        self.map(|c| c / rhs.clone())
+        self.map(|c| c / rhs)
     }
 }
 

--- a/src/vec/vector.rs
+++ b/src/vec/vector.rs
@@ -51,7 +51,7 @@ impl<T: Scalar, const N: usize> Vector<T, N> {
 
     /// Returns `true` if this vector is the zero vector (all components 0).
     pub fn is_zero(&self) -> bool {
-        self.0.iter().all(num_traits::Zero::is_zero)
+        self.0.iter().all(T::is_zero)
     }
 
     /// Returns a unit vector in x direction.


### PR DESCRIPTION
I used: `cargo clippy -- -W clippy::pedantic -W clippy::nursery -A clippy::missing_panics_doc -A clippy::missing_errors_doc -A clippy::must_use_candidate -A clippy::doc_markdown`

Maybe you can use `cargo clippy --- -W clippy::must_use_vandidate` and fix them by annotating `#[must_use]` to the functions clippy suggests